### PR TITLE
优化用户分组批量查询接口，并整合到批量post信息获取中

### DIFF
--- a/comment-service/comment-server/src/main/java/com/xueyu/comment/listener/PostMqListener.java
+++ b/comment-service/comment-server/src/main/java/com/xueyu/comment/listener/PostMqListener.java
@@ -1,0 +1,63 @@
+package com.xueyu.comment.listener;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.xueyu.comment.mapper.CommentMapper;
+import com.xueyu.comment.pojo.domain.Comment;
+import com.xueyu.comment.sdk.dto.CommentDTO;
+import com.xueyu.post.sdk.dto.PostDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.ExchangeTypes;
+import org.springframework.amqp.rabbit.annotation.Exchange;
+import org.springframework.amqp.rabbit.annotation.Queue;
+import org.springframework.amqp.rabbit.annotation.QueueBinding;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+
+import static com.xueyu.comment.sdk.constant.CommentMqContants.COMMENT_DELETE_KEY;
+import static com.xueyu.comment.sdk.constant.CommentMqContants.COMMENT_EXCHANGE;
+import static com.xueyu.post.sdk.constant.PostMqContants.POST_DELETE_KEY;
+import static com.xueyu.post.sdk.constant.PostMqContants.POST_EXCHANGE;
+
+/**
+ * 评论服务mq监听
+ * 服务队列命名准则：
+ * 服务 . 消息发送服务 . 操作行为
+ *
+ * @author durance
+ */
+@Slf4j
+@Component
+public class PostMqListener {
+
+	public static final String POST_DELETE_QUEUE = "comment.post.delete";
+
+	@Resource
+	CommentMapper commentMapper;
+
+	@Resource
+	RabbitTemplate rabbitTemplate;
+
+	@RabbitListener(bindings = @QueueBinding(
+			exchange = @Exchange(name = POST_EXCHANGE, type = ExchangeTypes.TOPIC),
+			value = @Queue(name = POST_DELETE_QUEUE),
+			key = POST_DELETE_KEY
+	))
+	public void addPostComment(PostDTO postDTO) {
+		log.info("帖子 id ->{},被删除", postDTO.getId());
+		// 删除对应的评论
+		LambdaQueryWrapper<Comment> wrapper = new LambdaQueryWrapper<>();
+		wrapper.eq(Comment::getPostId, postDTO.getId());
+		int deleteNum = commentMapper.delete(wrapper);
+		// 删除的数量，发送mq
+		CommentDTO commentDTO = new CommentDTO();
+		commentDTO.setAuthorId(postDTO.getUserId());
+		commentDTO.setPostId(postDTO.getId());
+		commentDTO.setUserId(postDTO.getUserId());
+		commentDTO.setEffectNum(deleteNum);
+		rabbitTemplate.convertAndSend(COMMENT_EXCHANGE, COMMENT_DELETE_KEY, commentDTO);
+	}
+
+}

--- a/comment-service/comment-server/src/main/java/com/xueyu/comment/service/impl/CommentServiceImpl.java
+++ b/comment-service/comment-server/src/main/java/com/xueyu/comment/service/impl/CommentServiceImpl.java
@@ -72,7 +72,7 @@ public class CommentServiceImpl extends ServiceImpl<CommentMapper, Comment> impl
 			throw new CommentException("评论与用户不匹配");
 		}
 		// 如果为根评论，需要连同回复评论一起删除，否则仅删除该条评论即可
-		int deleteNum = 0;
+		int deleteNum;
 		if (comment.getType().equals(CommentType.ROOT.getValue())) {
 			LambdaQueryWrapper<Comment> wrapper = new LambdaQueryWrapper<>();
 			wrapper.eq(Comment::getRootId, commentId);
@@ -87,7 +87,6 @@ public class CommentServiceImpl extends ServiceImpl<CommentMapper, Comment> impl
 		commentDTO.setPostId(comment.getPostId());
 		commentDTO.setCommentId(commentId);
 		rabbitTemplate.convertAndSend(COMMENT_EXCHANGE, COMMENT_DELETE_KEY, commentDTO);
-		// todo 添加作者id传输
 		return true;
 	}
 
@@ -109,7 +108,7 @@ public class CommentServiceImpl extends ServiceImpl<CommentMapper, Comment> impl
 		// 查询出所有有关的用户信息
 		List<Integer> userIds = new ArrayList<>(userIdSet);
 		Map<Integer, UserSimpleVO> userInfo = userClient.getUserDeatilInfoMap(userIds).getData();
-		List<CommentPostVO> rootComment = new ArrayList<>();
+		List<CommentPostVO> rootComment = new LinkedList<>();
 		// 创建关联map，key为根id，值为 子评论集合
 		Map<Integer, List<CommentAnswerVO>> answerCommentMap = new HashMap<>(10);
 		Map<CommentPostVO, Comment> linkMap = new HashMap<>(10);

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -43,6 +43,11 @@
 			<version>0.9.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis-reactive</artifactId>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/gateway-service/src/main/java/com/xueyu/gateway/config/KeyResolverConfig.java
+++ b/gateway-service/src/main/java/com/xueyu/gateway/config/KeyResolverConfig.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 /**
  * 定义令牌桶根据的key, 主机ip
  *
- * @author duranec
+ * @author durance
  */
 @Configuration
 public class KeyResolverConfig {

--- a/gateway-service/src/main/java/com/xueyu/gateway/config/KeyResolverConfig.java
+++ b/gateway-service/src/main/java/com/xueyu/gateway/config/KeyResolverConfig.java
@@ -1,0 +1,29 @@
+package com.xueyu.gateway.config;
+
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+/**
+ * 定义令牌桶根据的key, 主机ip
+ *
+ * @author duranec
+ */
+@Configuration
+public class KeyResolverConfig {
+
+	@Bean
+	public KeyResolver ipKeyResolver() {
+		return new KeyResolver() {
+			@Override
+			public Mono<String> resolve(ServerWebExchange exchange) {
+				return Mono.just(Objects.requireNonNull(exchange.getRequest().getRemoteAddress()).getHostName());
+			}
+		};
+	}
+
+}

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -29,3 +29,7 @@ spring:
           uri: lb://post-server
           predicates:
             - Path=/post/**
+        - id: comment-server
+          uri: lb://comment-server
+          predicates:
+            - Path=/comment/**

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -25,11 +25,29 @@ spring:
           uri: lb://user-server
           predicates:
             - Path=/user/**
+          filters:
+            - name: RequestRateLimiter #限流名称
+              args:
+                key-resolver: "#{@ipKeyResolver}"
+                redis-rate-limiter.replenishRate: 1 #令牌桶每秒填充平均速率
+                redis-rate-limiter.burstCapacity: 1 #令牌桶总容量
         - id: post-server
           uri: lb://post-server
           predicates:
             - Path=/post/**
+          filters:
+            - name: RequestRateLimiter
+              args:
+                key-resolver: "#{@ipKeyResolver}"
+                redis-rate-limiter.replenishRate: 1
+                redis-rate-limiter.burstCapacity: 1
         - id: comment-server
           uri: lb://comment-server
           predicates:
             - Path=/comment/**
+          filters:
+            - name: RequestRateLimiter
+              args:
+                key-resolver: "#{@ipKeyResolver}"
+                redis-rate-limiter.replenishRate: 1
+                redis-rate-limiter.burstCapacity: 1

--- a/gateway-service/src/main/resources/bootstrap.yml
+++ b/gateway-service/src/main/resources/bootstrap.yml
@@ -8,3 +8,5 @@ spring:
         shared-configs:
           - data-id: public-security.yaml
             refresh: true
+          - data-id: default-redis.yaml
+            refresh: true

--- a/post-service/post-sdk/src/main/java/com/xueyu/post/sdk/dto/PostDTO.java
+++ b/post-service/post-sdk/src/main/java/com/xueyu/post/sdk/dto/PostDTO.java
@@ -13,7 +13,7 @@ import java.sql.Timestamp;
 public class PostDTO {
 
 	/**
-	 * 自增id
+	 * 帖子id
 	 */
 	Integer id;
 

--- a/post-service/post-server/src/main/java/com/xueyu/post/controller/PostController.java
+++ b/post-service/post-server/src/main/java/com/xueyu/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.xueyu.post.controller;
 
 import com.xueyu.common.core.result.ListVO;
 import com.xueyu.common.core.result.RestResult;
+import com.xueyu.post.exception.PostException;
 import com.xueyu.post.pojo.domain.Post;
 import com.xueyu.post.pojo.vo.PostDetailVO;
 import com.xueyu.post.pojo.vo.PostListVO;
@@ -35,6 +36,10 @@ public class PostController {
 	 */
 	@PostMapping("add")
 	public RestResult<?> pushlishPost(Post post, MultipartFile[] files) {
+		int MAX_FILES = 9;
+		if (files.length >= MAX_FILES) {
+			throw new PostException("最多上传 9 张图");
+		}
 		Boolean sendStatus = postService.publishPost(post, files);
 		if (!sendStatus) {
 			return RestResult.fail("发布失败");
@@ -50,7 +55,7 @@ public class PostController {
 	 * @return 删除结果
 	 */
 	@PostMapping("delete")
-	public RestResult<?> deletePost(@NotNull Integer postId, @RequestHeader Integer userId) {
+	public RestResult<?> deletePost(@NotNull Integer postId, Integer userId) {
 		if (!postService.deletePost(postId, userId)) {
 			return RestResult.fail("删除失败");
 		}
@@ -65,7 +70,7 @@ public class PostController {
 	 * @return 帖子信息
 	 */
 	@GetMapping("list/all")
-	public RestResult<ListVO<PostListVO>> getAllPost(Integer current, Integer size) {
+	public RestResult<ListVO<PostListVO>> getAllPost(@RequestParam(defaultValue = "1") Integer current, @RequestParam(defaultValue = "10") Integer size) {
 		ListVO<PostListVO> postListByPage = postService.getPostListByPage(current, size, null);
 		return RestResult.ok(postListByPage);
 	}
@@ -78,7 +83,7 @@ public class PostController {
 	 * @return 帖子信息
 	 */
 	@GetMapping("list/user")
-	public RestResult<ListVO<PostListVO>> getUserPost(Integer current, Integer size, @RequestHeader Integer userId) {
+	public RestResult<ListVO<PostListVO>> getUserPost(@RequestParam(defaultValue = "1") Integer current, @RequestParam(defaultValue = "10") Integer size, @RequestHeader Integer userId) {
 		ListVO<PostListVO> postListByPage = postService.getPostListByPage(current, size, userId);
 		return RestResult.ok(postListByPage);
 	}

--- a/post-service/post-server/src/main/java/com/xueyu/post/service/impl/PostServiceImpl.java
+++ b/post-service/post-server/src/main/java/com/xueyu/post/service/impl/PostServiceImpl.java
@@ -31,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.annotation.Resource;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -143,12 +144,29 @@ public class PostServiceImpl extends ServiceImpl<PostMapper, Post> implements Po
 		// 统计postId, userId
 		List<Integer> postIds = new ArrayList<>();
 		List<Integer> authors = new ArrayList<>();
+		// 创建map postId | 点赞用户id列表数据，进行批量查询出用户id数据
+		Map<Integer, List<Integer>> likeUserIdsMap = new HashMap<>(records.size());
 		for (PostView postView : records) {
 			postIds.add(postView.getId());
 			authors.add(postView.getUserId());
 		}
+		// 查询所有帖子的点赞信息，并按照帖子id进行分配
+		LambdaQueryWrapper<LikePost> likeWrapper = new LambdaQueryWrapper<>();
+		likeWrapper.in(LikePost::getPostId, postIds);
+		List<LikePost> likePosts = likePostMapper.selectList(likeWrapper);
+		for (LikePost likePost : likePosts) {
+			if (likeUserIdsMap.containsKey(likePost.getPostId())) {
+				likeUserIdsMap.get(likePost.getPostId()).add(likePost.getUserId());
+			} else {
+				List<Integer> userIds = new ArrayList<>();
+				userIds.add(likePost.getUserId());
+				likeUserIdsMap.put(likePost.getPostId(), userIds);
+			}
+		}
 		// 查询并设置帖子用户信息
 		Map<Integer, UserSimpleVO> userInfos = userClient.getUserDeatilInfoMap(authors).getData();
+		// 查询所有帖子的点赞用户信息
+		Map<Integer, List<UserSimpleVO>> userLikeInfo = userClient.getUserInfoByGroup(likeUserIdsMap).getData();
 		// 查询所有图片信息
 		Map<Integer, List<ImageAnnexView>> postListImgs = imageAnnexService.getPostListImgs(postIds);
 		List<PostListVO> postData = new ArrayList<>();
@@ -159,18 +177,8 @@ public class PostServiceImpl extends ServiceImpl<PostMapper, Post> implements Po
 			postListVO.setUserInfo(userInfos.get(record.getUserId()));
 			// 设置该帖子图片信息
 			postListVO.setImgList(postListImgs.get(record.getId()));
-			// 创建用户id列表并设值用户值 todo 优化：添加用户服务接口，一次查询多组用户信息，减少client的调用
-			LambdaQueryWrapper<LikePost> likeWrapper = new LambdaQueryWrapper<>();
-			likeWrapper.eq(LikePost::getPostId, record.getId());
-			List<LikePost> likePosts = likePostMapper.selectList(likeWrapper);
-			List<Integer> userIds = new ArrayList<>();
-			for (LikePost likePost : likePosts) {
-				userIds.add(likePost.getUserId());
-			}
-			if (userIds.size() != 0) {
-				List<UserSimpleVO> userSimpleVOList = userClient.getUserDeatilInfoList(userIds).getData();
-				postListVO.setUserLikeBOList(userSimpleVOList);
-			}
+			// 设置点赞用户信息
+			postListVO.setUserLikeBOList(userLikeInfo.get(record.getId()));
 			postData.add(postListVO);
 		}
 		result.setRecords(postData);
@@ -184,7 +192,7 @@ public class PostServiceImpl extends ServiceImpl<PostMapper, Post> implements Po
 		// 核对该帖子是否已通过审核，如果未通过审核且不为自己的帖子，拒绝访问
 		if (!postView.getStatus().equals(PostStatus.PUBLIC.getValue())) {
 			if (userId == null || !userId.equals(postView.getUserId())) {
-				throw new PostException("未审核的post信息");
+				throw new PostException("未审核的帖子信息");
 			}
 		}
 		PostDetailVO postDetailVO = new PostDetailVO();

--- a/user-service/user-client/src/main/java/com/xueyu/user/client/UserClient.java
+++ b/user-service/user-client/src/main/java/com/xueyu/user/client/UserClient.java
@@ -44,4 +44,13 @@ public interface UserClient {
 	@GetMapping("private/user/detail/map")
 	RestResult<Map<Integer, UserSimpleVO>> getUserDeatilInfoMap(@RequestParam List<Integer> userIds);
 
+	/**
+	 * 根据传入id进行分组查询用户信息
+	 *
+	 * @param userGroupIds 分组id，key为分组id | value为该key所以对应的需要查询的用户id列表
+	 * @return 分组用户信息
+	 */
+	@GetMapping("private/user/list/group")
+	RestResult<Map<Integer, List<UserSimpleVO>>> getUserInfoByGroup(@RequestParam Map<Integer, List<Integer>> userGroupIds);
+
 }

--- a/user-service/user-client/src/main/java/com/xueyu/user/client/UserClientResolver.java
+++ b/user-service/user-client/src/main/java/com/xueyu/user/client/UserClientResolver.java
@@ -33,4 +33,10 @@ public class UserClientResolver implements UserClient {
 		return new RestResult<>(503, "fail");
 	}
 
+	@Override
+	public RestResult<Map<Integer, List<UserSimpleVO>>> getUserInfoByGroup(Map<Integer, List<Integer>> userGroupIds) {
+		log.error("user 服务异常：getUserInfoByGroup 请求失败");
+		return new RestResult<>(503, "fail");
+	}
+
 }

--- a/user-service/user-server/src/main/java/com/xueyu/user/controller/UserInfoController.java
+++ b/user-service/user-server/src/main/java/com/xueyu/user/controller/UserInfoController.java
@@ -58,4 +58,15 @@ public class UserInfoController {
 		return RestResult.ok(userViewService.getUserInfoListById(userIds));
 	}
 
+	/**
+	 * 根据传入id进行分组查询用户信息
+	 *
+	 * @param userGroupIds 分组id，key为分组id | value为该key所以对应的需要查询的用户id列表
+	 * @return 分组用户信息
+	 */
+	@GetMapping("list/group")
+	public RestResult<Map<Integer, List<UserSimpleVO>>> getUserInfoByGroup(@RequestParam Map<Integer, List<Integer>> userGroupIds) {
+		return RestResult.ok(userViewService.getUserInfoListByGroup(userGroupIds));
+	}
+
 }

--- a/user-service/user-server/src/main/java/com/xueyu/user/service/UserViewService.java
+++ b/user-service/user-server/src/main/java/com/xueyu/user/service/UserViewService.java
@@ -38,4 +38,12 @@ public interface UserViewService extends IService<UserView> {
 	 */
 	UserView getUserInfo(Integer userId);
 
+	/**
+	 * 根据传入id进行分组查询用户信息
+	 *
+	 * @param userGroupIds 分组id，key为分组id | value为该key所以对应的需要查询的用户id列表
+	 * @return 分组用户信息
+	 */
+	Map<Integer, List<UserSimpleVO>> getUserInfoListByGroup(Map<Integer, List<Integer>> userGroupIds);
+
 }

--- a/user-service/user-server/src/main/java/com/xueyu/user/service/impl/UserViewServiceImpl.java
+++ b/user-service/user-server/src/main/java/com/xueyu/user/service/impl/UserViewServiceImpl.java
@@ -46,4 +46,15 @@ public class UserViewServiceImpl extends ServiceImpl<UserViewMapper, UserView> i
 		return query().getBaseMapper().selectById(userId);
 	}
 
+	@Override
+	public Map<Integer, List<UserSimpleVO>> getUserInfoListByGroup(Map<Integer, List<Integer>> userGroupIds) {
+		// 创建响应体
+		Map<Integer, List<UserSimpleVO>> result = new HashMap<>(userGroupIds.size());
+		for (Map.Entry<Integer, List<Integer>> next : userGroupIds.entrySet()) {
+			List<UserSimpleVO> userInfoList = getUserInfoList(next.getValue());
+			result.put(next.getKey(), userInfoList);
+		}
+		return result;
+	}
+
 }


### PR DESCRIPTION
用户分组查询方法：
   因为不同帖子中可能会有相同的点赞用户，所以不能用sql来实现分组查询。
   这里本意想单独为这个业务逻辑实现一个根据postId进行分组的接口。但是这样写就有点耦合了
所以将该接口根据map数据结构解耦为根据传入的id进行查询。让有需要批量分组查询的接口都能够使用